### PR TITLE
Bump the pip group across 1 directory with 1 update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.26.0
+requests==2.31.0
 pytz==2024.1


### PR DESCRIPTION
Bumps the pip group with 1 update in the / directory: [requests](https://github.com/psf/requests).


Updates `requests` from 2.26.0 to 2.31.0
- [Release notes](https://github.com/psf/requests/releases)
- [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md)
- [Commits](https://github.com/psf/requests/compare/v2.26.0...v2.31.0)

---
updated-dependencies:
- dependency-name: requests dependency-type: direct:production dependency-group: pip-security-group ...